### PR TITLE
Update to fix slightly misleading How-To comment

### DIFF
--- a/XmpSamplePanel/js/xmp_bridge.js
+++ b/XmpSamplePanel/js/xmp_bridge.js
@@ -35,7 +35,9 @@
  * 		if(!readyState.isError) {
  * 		
  * 			// now we're ready to go.
- * 			XMPBridge.read('NS_DC', 'title');
+ * 			XMPBridge.toNamespaceURI('NS_DC', function(namespaceUri) {
+ * 				XMPBridge.read(namespaceUri, 'title');
+ * 			});
  * 		
  * 		} else {
  * 			// error handling.


### PR DESCRIPTION
The example for the excellent XMPBridge unfortunately leads to an `Unregistered namespaceURI schema` error when used.

```
 *          // now we're ready to go.
 *          XMPBridge.read('NS_DC', 'title');
 *          
```

Instead the example should probably include reference to the fact that you can get the the namespace URI from Adobe's constants like NS_DC by calling `XMPBridge.toNamespaceURI()`

```
 *          // now we're ready to go.
 *          XMPBridge.toNamespaceURI('NS_DC', function(namespaceUri) {
 *              XMPBridge.read(namespaceUri, 'title');
 *          });
```
