### PR TITLE
account for decimal color values with Math.round()

### DIFF
--- a/AfterEffectsPanel/ext.js
+++ b/AfterEffectsPanel/ext.js
@@ -131,7 +131,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/PProPanel/ext.js
+++ b/PProPanel/ext.js
@@ -176,7 +176,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/demo/changeMarker/ext.js
+++ b/htmlStandAlone/demo/changeMarker/ext.js
@@ -313,7 +313,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/demo/concatenation/ext.js
+++ b/htmlStandAlone/demo/concatenation/ext.js
@@ -68,7 +68,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/demo/exportResult/ext.js
+++ b/htmlStandAlone/demo/exportResult/ext.js
@@ -61,7 +61,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/demo/getMediaProperties/ext.js
+++ b/htmlStandAlone/demo/getMediaProperties/ext.js
@@ -63,7 +63,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/demo/saveAsset/ext.js
+++ b/htmlStandAlone/demo/saveAsset/ext.js
@@ -63,7 +63,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/demo/selectedAsset/ext.js
+++ b/htmlStandAlone/demo/selectedAsset/ext.js
@@ -62,7 +62,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/demo/selectedMarker/ext.js
+++ b/htmlStandAlone/demo/selectedMarker/ext.js
@@ -253,7 +253,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/demo/transcode/ext.js
+++ b/htmlStandAlone/demo/transcode/ext.js
@@ -67,7 +67,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/demo/transfer/ext.js
+++ b/htmlStandAlone/demo/transfer/ext.js
@@ -71,7 +71,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/demo/writeMetadata/ext.js
+++ b/htmlStandAlone/demo/writeMetadata/ext.js
@@ -58,7 +58,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/htmlStandAlone/lib/utility.js
+++ b/htmlStandAlone/lib/utility.js
@@ -219,7 +219,7 @@ function toHex(color, delta) {
             computedValue = 255;
         }
 
-        computedValue = computedValue.toString(16);
+        computedValue = Math.round(computedValue).toString(16);
         return computedValue.length == 1 ? "0" + computedValue : computedValue;
     }
 

--- a/simpledissolve/SimpleDissolveApplyFilter/js/themeManager.js
+++ b/simpledissolve/SimpleDissolveApplyFilter/js/themeManager.js
@@ -19,7 +19,7 @@ var themeManager = (function () {
             
             computedValue = Math.floor(computedValue);
     
-            computedValue = computedValue.toString(16);
+            computedValue = Math.round(computedValue).toString(16);
             return computedValue.length === 1 ? "0" + computedValue : computedValue;
         }
     

--- a/simpledissolve/SimpleDissolveUI/js/themeManager.js
+++ b/simpledissolve/SimpleDissolveUI/js/themeManager.js
@@ -19,7 +19,7 @@ var themeManager = (function () {
             
             computedValue = Math.floor(computedValue);
     
-            computedValue = computedValue.toString(16);
+            computedValue = Math.round(computedValue).toString(16);
             return computedValue.length === 1 ? "0" + computedValue : computedValue;
         }
     

--- a/webgl_threejs/js/themeManager.js
+++ b/webgl_threejs/js/themeManager.js
@@ -16,7 +16,7 @@ var themeManager = (function () {
                 computedValue = 255;
             }
     
-            computedValue = computedValue.toString(16);
+            computedValue = Math.round(computedValue).toString(16);
             return computedValue.length === 1 ? "0" + computedValue : computedValue;
         }
     


### PR DESCRIPTION
As of Premiere Pro 9.1, we found that color values often come across as decimal values. This generates an invalid HEX color value. Something like: `#35.435.435.4`

In this change, I use `Math.round` to normalize the color values before converting them to HEX.

Though I saw this issue in Premiere 9.1, I have updated all instances of `toHex` that I could find.