### PR TITLE
Expand nodeid documentation

### DIFF
--- a/TypeScript/PProPanel-vscode/dom_app/types/PremierePro.11.1.2.d.ts
+++ b/TypeScript/PProPanel-vscode/dom_app/types/PremierePro.11.1.2.d.ts
@@ -379,6 +379,9 @@ declare class ProjectItem extends PremiereObject
      * The name of the projectItem, as a string. Read/Write.
      */
     name: string;
+    /**
+     * The projectItem's position within the project 'tree'; not guaranteed to be unique forever.
+     */
     readonly nodeId: string;
     /**
      * The path to the projectItem, within the project.

--- a/TypeScript/typings/PremierePro.11.1.2.d.ts
+++ b/TypeScript/typings/PremierePro.11.1.2.d.ts
@@ -379,6 +379,9 @@ declare class ProjectItem extends PremiereObject
      * The name of the projectItem, as a string. Read/Write.
      */
     name: string;
+    /**
+     * The projectItem's position within the project 'tree'; not guaranteed to be unique forever.
+     */
     readonly nodeId: string;
     /**
      * The path to the projectItem, within the project.


### PR DESCRIPTION
Bruce ["documented"](https://forums.adobe.com/message/9677988#9677988) the `ProjectItem.nodeId` property. This change ensures that the documentation makes it somewhere usable.