### PR TITLE
Improve script-calling and add sample using new func

### DIFF
--- a/PProPanel/PProPanel.jsx
+++ b/PProPanel/PProPanel.jsx
@@ -19,5 +19,35 @@ $._ext = {
 				$._ext.evalFile(jsxFile);
 			}
 		}
+	},
+	// entry-point function to call scripts more easily & reliably
+	callScript: function(dataStr) {
+		try {
+			var dataObj = JSON.parse(decodeURIComponent(dataStr));
+			if (
+				!dataObj ||
+				!dataObj.namespace ||
+				!dataObj.scriptName ||
+				!dataObj.args
+			) {
+				throw new Error('Did not provide all needed info to callScript!');
+			}
+			// call the specified jsx-function
+			var result = $[dataObj.namespace][dataObj.scriptName].apply(
+				null,
+				dataObj.args
+			);
+			// build the payload-object to return
+			var payload = {
+				err: 0,
+				result: result
+			};
+			return encodeURIComponent(JSON.stringify(payload));
+		} catch (err) {
+			var payload = {
+				err: err
+			};
+			return encodeURIComponent(JSON.stringify(payload));
+		}
 	}
 };

--- a/PProPanel/index.html
+++ b/PProPanel/index.html
@@ -327,6 +327,7 @@
 		<button class="controlBg textStyle" id="btn_PPRO29" onClick="evalScript('$._PPP_.onPlayWithKeyframes()')">Manipulate keyframes</button>
 		<button class="controlBg textStyle" id="btn_PPRO30" onClick="evalScript('$._PPP_.insertOrAppend()')">insert or append to active sequence</button>
 		<button class="controlBg textStyle" id="btn_PPRO31" onClick="evalScript('$._PPP_.overWrite()')">overwrite at CTI</button>
+		<button class="controlBg textStyle" id="btn_PPRO32" onClick="createFolders()">Create Deep Folder-Structure (using callScript)</button>
 		<div id="dragthing" draggable="true" ondragstart="dragHandler(event)">drag me</div>
 	</body>
 	<script>
@@ -345,6 +346,24 @@
 			    csInterface.openURLInDefaultBrowser(path);		
 		    }
 	  	};
+
+		var createFolders = function() {
+		  var csInterface = new CSInterface();
+		  csInterface.callScript(
+		    '_PPP_',
+		    'createDeepFolderStructure',
+		    function(res) {
+		      console.log('Successfully created folders!');
+		    },
+		    function(err) {
+		      console.error(err);
+					alert(err.message);
+		    },
+				['This', 'is', 'a', 'very', 'deep', 'folder', 'structure'], // 1st argument
+				6 // 2nd argument
+		  );
+		};
+
 	</script>
 	</script>
 </html>

--- a/PProPanel/jsx/PPRO/Premiere.jsx
+++ b/PProPanel/jsx/PPRO/Premiere.jsx
@@ -1,5 +1,25 @@
 $._PPP_={
 
+	createDeepFolderStructure : function(foldersArray, maxDepth) {
+		if (typeof foldersArray !== 'object' || foldersArray.length <= 0) {
+			throw new Error('No valid folders array was provided!');
+		}
+
+		// if the first folder already exists, throw error
+		for (var i = 0; i < app.project.rootItem.children.numItems; i++) {
+			var curChild = app.project.rootItem.children[i];
+			if (curChild.type === ProjectItemType.BIN && curChild.name === foldersArray[0]) {
+				throw new Error('Folder with name "' + curChild.name + '" already exists!');
+			}
+		}
+
+		// create the deep folder structure
+		var currentBin = app.project.rootItem.createBin(foldersArray[0]);
+		for (var i = 1; i < foldersArray.length && i < maxDepth; i++) {
+			currentBin = currentBin.createBin(foldersArray[i]);
+		}
+	},
+
 	getVersionInfo : function() {
 		return 'PPro ' + app.version + 'x' + app.build;
 	},


### PR DESCRIPTION
I wanted to share with you my approach to call JSX functions as an alternative to the "evalScript" function.

My "callScript" function enables:

* Calling a jsx function with any arguments you like
* Ensuring correct parsing of passed arguments (escaping special characters)
* A Result & Error callback

This PR consists of:
1. The callScript function in CSInterface
2. The callScript jsx-function as entry-point in `PProPanel.jsx`
3. An example how to use this, using a new "Create Deep Folder-Structure" button.

With ES6 and promises, this would look even nicer. But to fit into this PProPanel example, I kept the general vanilla js style.