### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Remember that although these extensions are initially setup for a particular ver
 | [RSSReader](https://github.com/Adobe-CEP/Samples/tree/master/RSSReader) | Demonstrates using 3rd party NPM modules in a CEP 5 extension. | InDesign/InCopy, Illustrator, Photoshop |
 | [SimpleDissolve](https://github.com/Adobe-CEP/Samples/tree/master/simpledissolve) | | Photoshop |
 | [Trello](https://github.com/Adobe-CEP/Samples/tree/master/Trello) | Demonstrates loading an external website in an iFrame. | Photoshop, Illustrator, Premiere Pro |
-| [TypeScript](https://github.com/Adobe-CEP/Samples/tree/master/Trello) | Demonstrates multiple sample codes thata demonstrate what's possible to build inside Premiere Pro. | Premiere Pro |
+| [TypeScript](https://github.com/Adobe-CEP/Samples/tree/master/Typescript) | Demonstrates multiple sample codes thata demonstrate what's possible to build inside Premiere Pro. | Premiere Pro |
 | [UI Showcase](https://github.com/Adobe-CEP/Samples/tree/master/UI_Showcase) | Demonstrates using common JavaScript UI frameworks in CEP extensions. | Photoshop, Illustrator, Premiere Pro |
 | [WebGL with three.js (Contributed by Davide Deraedt)](https://github.com/Adobe-CEP/Samples/tree/master/webgl_threejs) | Demonstrates WebGL with `three.js` | Photoshop |
 | [Websockets](https://github.com/Adobe-CEP/Samples/tree/master/Websocket) | Demonstrates using web sockets in an extension. | Photoshop, Illustrator, Premiere Pro |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Remember that although these extensions are initially setup for a particular ver
 | [RSSReader](https://github.com/Adobe-CEP/Samples/tree/master/RSSReader) | Demonstrates using 3rd party NPM modules in a CEP 5 extension. | InDesign/InCopy, Illustrator, Photoshop |
 | [SimpleDissolve](https://github.com/Adobe-CEP/Samples/tree/master/simpledissolve) | | Photoshop |
 | [Trello](https://github.com/Adobe-CEP/Samples/tree/master/Trello) | Demonstrates loading an external website in an iFrame. | Photoshop, Illustrator, Premiere Pro |
-| [TypeScript](https://github.com/Adobe-CEP/Samples/tree/master/Typescript) | Demonstrates multiple sample codes thata demonstrate what's possible to build inside Premiere Pro. | Premiere Pro |
+| [TypeScript](https://github.com/Adobe-CEP/Samples/tree/master/TypeScript) | Demonstrates multiple sample codes thata demonstrate what's possible to build inside Premiere Pro. | Premiere Pro |
 | [UI Showcase](https://github.com/Adobe-CEP/Samples/tree/master/UI_Showcase) | Demonstrates using common JavaScript UI frameworks in CEP extensions. | Photoshop, Illustrator, Premiere Pro |
 | [WebGL with three.js (Contributed by Davide Deraedt)](https://github.com/Adobe-CEP/Samples/tree/master/webgl_threejs) | Demonstrates WebGL with `three.js` | Photoshop |
 | [Websockets](https://github.com/Adobe-CEP/Samples/tree/master/Websocket) | Demonstrates using web sockets in an extension. | Photoshop, Illustrator, Premiere Pro |


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [x] A documentation contained within this repo.

## Versions

- [x] CEP version(s) tested [must be `8.x+` for this repo]:
- [x] Supported/tested CC app(s) and version(s):


## Description of the pull request
Link in README.md to the TypeScript sample was incorrectly linked to the Trello sample

Change link from Samples/Trello -> Samples/TypeScript