### PR TITLE
Do not mutate time var in exportCurrentFrameAsPNG

### DIFF
--- a/PProPanel/jsx/PPRO/Premiere.jsx
+++ b/PProPanel/jsx/PPRO/Premiere.jsx
@@ -79,9 +79,9 @@ $._PPP_={
 			// Create a file name based on timecode of frame.
 			var time			= activeSequence.CTI.timecode; 	// CTI = Current Time Indicator.
 			var removeThese 	= /:|;/ig;    // Why? Because Windows chokes on colons.
-			time = time.replace(removeThese, '_');
+			var safeTimeStr         = time.replace(removeThese, '_');
 			var outputPath		= new File("~/Desktop");
-			var outputFileName	= outputPath.fsName + $._PPP_.getSep() + time + '___' + activeSequence.name;
+			var outputFileName	= outputPath.fsName + $._PPP_.getSep() + safeTimeStr + '___' + activeSequence.name;
 			activeSequence.exportFramePNG(time, outputFileName);
 		} else {
 			$._PPP_.updateEventPanel("No active sequence.");


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [ ] A documentation contained within this repo.
- [x] A sample contained within this repo.
- [ ] A new sample to be included in this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:


## Versions

- [x] CEP version(s) tested [must be `8.x+` for this repo]:

## Description of the pull request

Export current frame as PNG in PProPanel/jsx/PPRO/Premiere.jsx file always defaults to the first frame of the active sequence, because the time variable is mutated to remove colons to make it Windows safe, and presumably the exportCurrentFramePNG doesn't understand this mutated representation of the timestamp.

Instead assign the windows safe representation of the timestamp to a new variable, and pass the original timestamp into the exportCurrentFrame method.