### PR TITLE
Fix PProPanel styling

### DIFF
--- a/PProPanel/css/style.css
+++ b/PProPanel/css/style.css
@@ -12,14 +12,20 @@
 * written permission of Adobe. 
 **************************************************************************/
 
-p {
+* {
 	font-family: "LucidaGrande", sans-serif;
+}
+
+p {
 	text-align:center;
+}
+
+a {
+        color: #8080ff;
 }
 
 button
 {
-	font-family: "LucidaGrande", sans-serif;
 	font-size:12px;
 	border:1px solid;
 	height:20px;

--- a/PProPanel/ext.js
+++ b/PProPanel/ext.js
@@ -161,6 +161,8 @@ function updateThemeWithAppSkinInfo(appSkinInfo) {
 		addRule(styleId, ".default", "font-size:" + appSkinInfo.baseFontSize + "px" + "; color:" + fontColor + "; background-color:" + toHex(panelBackgroundColor) + ";");
 		addRule(styleId, "button, select, input[type=text], input[type=button], input[type=submit]", borderColor);	   
 		addRule(styleId, "p", "color:" + fontColor + ";");	  
+		addRule(styleId, "h1", "color:" + fontColor + ";");	  
+		addRule(styleId, "h2", "color:" + fontColor + ";");	  
 		addRule(styleId, "button", "font-family: " + appSkinInfo.baseFontFamily + ", Arial, sans-serif;");	  
 		addRule(styleId, "button", "color:" + fontColor + ";");	   
 		addRule(styleId, "button", "font-size:" + (1.2 * appSkinInfo.baseFontSize) + "px;");	

--- a/PProPanel/index.html
+++ b/PProPanel/index.html
@@ -22,7 +22,7 @@
 	<script src="./lib/CSInterface.js"></script>
 	<script src="./lib/jquery-1.9.1.js"></script>
 	<script src="./lib/Vulcan.js"></script>
-	<link href="css/style.css" rel="stylesheet" type="text/css">
+	<link id="ppstyle" href="css/style.css" rel="stylesheet" type="text/css">
 	<script type="text/javascript">
 		$(document).ready(function () {
 


### PR DESCRIPTION
Set id of stylesheet so dynamic styles work, and clean up a few
misc colors and fonts

# Submit a pull request

## CLA

- [x ] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [ ] A documentation contained within this repo.
- [x ] A sample contained within this repo.
- [ ] A new sample to be included in this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:


## Versions

- [ 8.x+ ] CEP version(s) tested [must be `8.x+` for this repo]:
- [ Premiere Pro 13.0.3x9 ] Supported/tested CC app(s) and version(s):


## Description of the pull request

At least on my Windows machine, loading the PProPanel sample into Premiere Pro CC 2019 shows bad style problems -- the buttons are unstyled, the headers are black (on the dark gray background) etc.
Most of that is because the dynamic styles are applied to a DOM element with ID 'ppstyle' but the stylesheet is not tagged with that ID. This PR corrects that, as well as globally setting the font and fixing h1 and h2 colors.