### PR TITLE
addEventListener error. Using bind to align with other events

### DIFF
--- a/PProPanel/jsx/PPRO/Premiere.jsx
+++ b/PProPanel/jsx/PPRO/Premiere.jsx
@@ -180,7 +180,7 @@ $._PPP_={
 	},
 
 	registerProjectPanelSelectionChangedFxn: function () {
-		app.addEventListener("onSourceClipSelectedInProjectPanel", $._PPP_.projectPanelSelectionChanged);
+		app.bind("onSourceClipSelectedInProjectPanel", $._PPP_.projectPanelSelectionChanged);
 	},
 
 	saveCurrentProjectLayout: function () {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x ] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [ ] A documentation contained within this repo.
- [x ] A sample contained within this repo.
- [ ] A new sample to be included in this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:


## Versions

- [ ] CEP version(s) tested [must be `8.x+` for this repo]:
- [ ] Supported/tested CC app(s) and version(s):


## Description of the pull request
Was not able to get realtime updating of selected items to work in Premiere. Changing this to an app.bind fixed the issue for me